### PR TITLE
bug fix : mirador won't show after enabling annotation plugin

### DIFF
--- a/src/View/Helper/Mirador.php
+++ b/src/View/Helper/Mirador.php
@@ -223,22 +223,22 @@ class Mirador extends AbstractHelper
         $siteConfig = trim($siteConfig);
 
         if ($internalConfig) {
+            $internalConfigAnnotation = <<<'JS'
+annotation: {
+    adapter: (canvasId) => window.miradorAnnotationServerAdapter(canvasId),
+}
+JS;
+            $internalConfigWindow = <<<'JS'
+window: {
+    defaultSideBarPanel: 'annotations',
+    sideBarOpenByDefault: false,
+}
+JS;
             if ($siteConfig && $siteConfig !== '{}') {
                 // The admin may forget to wrap config.
                 if (mb_substr($siteConfig, 0, 1) !== '{') {
                     $siteConfig = "{\n" . $siteConfig . "\n}";
                 }
-                $internalConfigAnnotation = <<<'JS'
-annotation: {
-        adapter: (canvasId) => window.miradorAnnotationServerAdapter(canvasId),
-    }
-JS;
-                $internalConfigWindow = <<<'JS'
-window: {
-        defaultSideBarPanel: 'annotations',
-        sideBarOpenByDefault: false,
-    }
-JS;
                 $hasAnnotation = strpos($siteConfig, 'annotation:') || strpos($siteConfig, '"annotation":') || strpos($siteConfig, "'annotation':");
                 $hasWindow = strpos($siteConfig, 'window:') || strpos($siteConfig, '"window":') || strpos($siteConfig, "'window':");
                 if ($hasAnnotation && $hasWindow) {


### PR DESCRIPTION
After enabling annotation plugin on Mirador v3, an error shows that some variables weren't declared line 254 on Mirador.php
This simple fix looks good to me (moving the 2 variables declarations a few lines above, before the if statement). 

> Notice: Undefined variable: internalConfigAnnotation in /www/omeka-s/modules/Mirador/src/View/Helper/Mirador.php on line 254 Notice: Undefined variable: internalConfigWindow in /www/omeka-s/modules/Mirador/src/View/Helper/Mirador.php on line 254
