### PR TITLE
Do not render OCR panel if there are no OCR texts (files) available (module Mirador)

### DIFF
--- a/asset/css/mirador.css
+++ b/asset/css/mirador.css
@@ -18,6 +18,14 @@
     .mirador-viewer .manifest-info .window-manifest-title {
         line-height: initial;
     }
+    /*
+     * Override MUI's default `position: fixed` on `.MuiDrawer-paper`.
+     * This ensures the drawer (i.e. the element that contains the sidebar buttons) is positioned within the Mirador
+     * viewer rather than being anchored to the far left of the viewport edge.
+     */
+    .mirador .MuiDrawer-root.MuiDrawer-docked > .MuiDrawer-paper {
+        position: relative;
+    }
     @media (min-width: 1200px) {
         .modal-dialog {
             width: 1440px;

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
             "asset/vendor/mirador-2-plugins/": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.10/mirador-2-plugins.tar.gz",
             "asset/vendor/mirador-3/": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-3.4.3.tar.gz",
             "asset/vendor/mirador/mirador.min.js": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador.min.js",
-            "asset/vendor/mirador-esm/": "https://github.com/mcoonen/Omeka-S-module-Mirador/releases/download/3.4.17-pl1/mirador-esm.tar.gz"
+            "asset/vendor/mirador-esm/": "https://github.com/mcoonen/Omeka-S-module-Mirador/releases/download/3.4.17-pl2/mirador-esm.tar.gz"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
             "asset/vendor/mirador-2-plugins/": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.10/mirador-2-plugins.tar.gz",
             "asset/vendor/mirador-3/": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-3.4.3.tar.gz",
             "asset/vendor/mirador/mirador.min.js": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador.min.js",
-            "asset/vendor/mirador-esm/": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-esm.tar.gz"
+            "asset/vendor/mirador-esm/": "https://github.com/mcoonen/Omeka-S-module-Mirador/releases/download/3.4.17-pl1/mirador-esm.tar.gz"
         }
     }
 }

--- a/config/module.ini
+++ b/config/module.ini
@@ -9,5 +9,5 @@ module_link  = "https://gitlab.com/Daniel-KM/Omeka-S-module-Mirador"
 dev_link     = "https://gitlab.com/Daniel-KM/Omeka-S-module-Mirador"
 support_link = "https://gitlab.com/Daniel-KM/Omeka-S-module-Mirador/-/issues"
 configurable = true
-version      = "3.4.17-pl1"
+version      = "3.4.17-pl2"
 omeka_version_constraint = "^3.1 || ^4.0"

--- a/config/module.ini
+++ b/config/module.ini
@@ -9,5 +9,5 @@ module_link  = "https://gitlab.com/Daniel-KM/Omeka-S-module-Mirador"
 dev_link     = "https://gitlab.com/Daniel-KM/Omeka-S-module-Mirador"
 support_link = "https://gitlab.com/Daniel-KM/Omeka-S-module-Mirador/-/issues"
 configurable = true
-version      = "3.4.17"
+version      = "3.4.17-pl1"
 omeka_version_constraint = "^3.1 || ^4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "omeka-s-module-mirador",
     "private": true,
-    "version": "3.4.17",
+    "version": "3.4.17-pl1",
     "type": "module",
     "license": "CECILL-2.1",
     "description": "Mirador (module for Omeka S)",
@@ -19,7 +19,7 @@
         "mirador-dl-plugin": "^1.0.0",
         "mirador-image-tools": "^1.0.0",
         "mirador-image-cropper": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-image-cropper-3.0.0.tgz",
-        "mirador-ocr-helper": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-ocr-helper-2.1.0.tgz",
+        "mirador-ocr-helper": "https://github.com/mcoonen/mirador-ocr-helper/releases/download/2.1.1/mirador-ocr-helper-2.1.1.tgz",
         "mirador-physical-ruler": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-physical-ruler-1.0.0.tgz",
         "mirador-rotation": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-rotation-4.1.0.tgz",
         "mirador-share-plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "omeka-s-module-mirador",
     "private": true,
-    "version": "3.4.17-pl1",
+    "version": "3.4.17-pl2",
     "type": "module",
     "license": "CECILL-2.1",
     "description": "Mirador (module for Omeka S)",
@@ -19,7 +19,7 @@
         "mirador-dl-plugin": "^1.0.0",
         "mirador-image-tools": "^1.0.0",
         "mirador-image-cropper": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-image-cropper-3.0.0.tgz",
-        "mirador-ocr-helper": "https://github.com/mcoonen/Omeka-S-module-Mirador/releases/download/3.4.17-pl1/mirador-ocr-helper-2.1.1.tgz",
+        "mirador-ocr-helper": "https://github.com/mcoonen/Omeka-S-module-Mirador/releases/download/3.4.17-pl2/mirador-ocr-helper-2.1.1.tgz",
         "mirador-physical-ruler": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-physical-ruler-1.0.0.tgz",
         "mirador-rotation": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-rotation-4.1.0.tgz",
         "mirador-share-plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "mirador-dl-plugin": "^1.0.0",
         "mirador-image-tools": "^1.0.0",
         "mirador-image-cropper": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-image-cropper-3.0.0.tgz",
-        "mirador-ocr-helper": "https://github.com/mcoonen/mirador-ocr-helper/releases/download/2.1.1/mirador-ocr-helper-2.1.1.tgz",
+        "mirador-ocr-helper": "https://github.com/mcoonen/Omeka-S-module-Mirador/releases/download/3.4.17-pl1/mirador-ocr-helper-2.1.1.tgz",
         "mirador-physical-ruler": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-physical-ruler-1.0.0.tgz",
         "mirador-rotation": "https://github.com/Daniel-KM/Omeka-S-module-Mirador/releases/download/3.4.17/mirador-rotation-4.1.0.tgz",
         "mirador-share-plugin": "^1.0.0",


### PR DESCRIPTION
This PR includes the changes made in the https://github.com/Daniel-KM/mirador-ocr-helper/pull/1 and downloads the compiled and minified JS code as mirador-esm.tar.gz (`composer.json`) and mirador-ocr-helper-2.1.1.tgz (`package.json`).

See https://github.com/Daniel-KM/mirador-ocr-helper/pull/1 for screenshots of this fix.

It also contains a fix in the CSS to render the sidebar **inside** the Mirador viewer instead of positioning it on the left of the viewport. See screenshots below.

### Before
<img width="986" height="867" alt="23-sidebar-mirador-3 4 17-pl1" src="https://github.com/user-attachments/assets/06016ae6-9e05-41e7-9a32-b1be1c81db31" />


### After
<img width="1012" height="869" alt="25-sidebar-mirador-3 4 17-pl2" src="https://github.com/user-attachments/assets/1bf198c9-988a-4789-88dc-763b1a98f260" />
